### PR TITLE
[SCRUM-482] remove: TurnOnOpening, TurnOnOpeningStatement인터페이스

### DIFF
--- a/Source/QuackToHell/UI/QCourtUIManager.cpp
+++ b/Source/QuackToHell/UI/QCourtUIManager.cpp
@@ -98,13 +98,6 @@ bool AQCourtUIManager::IsCourtMap()
 
 
 
-void AQCourtUIManager::TurnOnOpeningStatement_Implementation()
-{
-	UE_LOG(LogLogic, Log, TEXT("모두진술 연출 ~~ 미구현"));
-}
-
-
-
 
 
 
@@ -253,9 +246,4 @@ void AQCourtUIManager::Tick(float DeltaTime)
 
 }
 
-
-void AQCourtUIManager::TurnOnOpening_Implementation()
-{
-	UE_LOG(LogLogic, Log, TEXT("재판 시작 연출 ~~ 미구현"));
-}
 

--- a/Source/QuackToHell/UI/QCourtUIManager.h
+++ b/Source/QuackToHell/UI/QCourtUIManager.h
@@ -41,20 +41,6 @@ class QUACKTOHELL_API AQCourtUIManager : public AActor
 public:
 	// Called every frame
 	virtual void Tick(float DeltaTime) override;
-public:
-	/*연출켜기*/
-	/**
-	 * @brief 재판 도입부 연출을 틉니다.
-	 * 
-	 */
-	UFUNCTION(NetMulticast, Reliable)
-	void TurnOnOpening();
-	/**
-	 * @brief 모두진술 연출을 틉니다.
-	 *
-	 */
-	UFUNCTION(NetMulticast, Reliable)
-	void TurnOnOpeningStatement();
 
 public:
 	/*깔끔 ver: 연출켜기*/


### PR DESCRIPTION
이유: Enum을 인자로 넣는 버전으로 간소화함.
