### PR TITLE
fix: 클라화면 대화걸시 런타임종료

### DIFF
--- a/Source/QuackToHell/NPC/QDynamicNPCController.cpp
+++ b/Source/QuackToHell/NPC/QDynamicNPCController.cpp
@@ -111,7 +111,7 @@ void AQDynamicNPCController::UnFreezePawn()
 void AQDynamicNPCController::FreezePawn()
 {
     //폰 정보 가져오기
-    TObjectPtr<APawn> ControlledPawn = this->GetPawn();
+    APawn* ControlledPawn = this->GetPawn();
     if (!ControlledPawn) {
         return;
     }


### PR DESCRIPTION
원인: 일반포인터로 안 받아서 null로받아옴.
